### PR TITLE
Add Background Blur to Enhance Small Album Cover Visibility

### DIFF
--- a/python/spotipiEinkDisplay.py
+++ b/python/spotipiEinkDisplay.py
@@ -9,7 +9,7 @@ import traceback
 import configparser
 import requests
 import signal
-from PIL import Image, ImageDraw, ImageFont, ImageOps, ImageEnhance
+from PIL import Image, ImageDraw, ImageFont, ImageOps, ImageEnhance, ImageFilter
 
 
 # recursion limiter for get song info to not go to infinity as decorator
@@ -218,6 +218,7 @@ class SpotipiEinkDisplay:
         offset_px_bottom = self.config.getint('DEFAULT', 'offset_px_bottom')
         offset_text_px_shadow = self.config.getint('DEFAULT', 'offset_text_px_shadow')
         text_direction = self.config.get('DEFAULT', 'text_direction')
+        background_blur = self.config.getint('DEFAULT', 'background_blur', fallback=0)
         # The width and height of the background
         bg_w, bg_h = image.size
         if self.config.get('DEFAULT', 'background_mode') == 'fit':
@@ -240,6 +241,8 @@ class SpotipiEinkDisplay:
                 # no need to repeat just crop
                 image_new = image.crop((0, 0, self.config.getint('DEFAULT', 'width'), self.config.getint('DEFAULT', 'height')))
         if self.config.getboolean('DEFAULT', 'album_cover_small'):
+            if background_blur > 0:
+                image_new = image_new.filter(ImageFilter.GaussianBlur(background_blur))
             cover_smaller = image.resize([album_cover_small_px, album_cover_small_px], Image.LANCZOS)
             album_pos_x = (self.config.getint('DEFAULT', 'width') - album_cover_small_px) // 2
             image_new.paste(cover_smaller, [album_pos_x, offset_px_top])

--- a/setup.sh
+++ b/setup.sh
@@ -173,6 +173,9 @@ echo "; disable smaller album cover set to False" >> ${install_path}/config/eink
 echo "; if disabled top offset is still calculated like as the following:" >> ${install_path}/config/eink_options.ini
 echo "; offset_px_top + album_cover_small_px" >> ${install_path}/config/eink_options.ini
 echo "album_cover_small = False" >> ${install_path}/config/eink_options.ini
+echo "; Blur intensity for the background image when album_cover_small is enabled" >> ${install_path}/config/eink_options.ini
+echo "; 0 = no blur, higher values increase the blur effect" >> ${install_path}/config/eink_options.ini
+echo "background_blur = 5" >> ${install_path}/config/eink_options.ini
 echo "; cleans the display every 20 picture" >> ${install_path}/config/eink_options.ini
 echo "; this takes ~60 seconds" >> ${install_path}/config/eink_options.ini
 echo "display_refresh_counter = 20" >> ${install_path}/config/eink_options.ini


### PR DESCRIPTION
### Description
I noticed that when `album_cover_small = True`, the small album cover sometimes blends too much with the background, making it hard to distinguish. To address this, I added a configurable background blur option (`background_blur`) that applies a Gaussian blur effect to the background image.

This makes the smaller album cover stand out more clearly, improving visibility and contrast. The blur intensity is fully adjustable via the `eink_options.ini` file, so users can fine-tune the effect to their preference.

---

### Changes I Made
1. **New Config Option (`eink_options.ini`):**
 ```ini
 ; Blur intensity for the background image when album_cover_small is enabled
; 0 = no blur, higher values increase the blur effect
background_blur = 5
 ```
2. **Modified `_gen_pic` method in `spotipiEinkDisplay.py`**
I introduced a new variable that reads the blur value from the config and applies a Gaussian blur if `album_cover_small is enabled`:

**New Lines added:**
```python
background_blur = self.config.getint('DEFAULT', 'background_blur', fallback=0)
```
```python
if self.config.getboolean('DEFAULT', 'album_cover_small'):
    if background_blur > 0:
        image_new = image_new.filter(ImageFilter.GaussianBlur(background_blur))
```

---

### How to Use

- Edit `eink_options.ini` and set `background_blur` to a preferred value.
- `0` disables the blur, while higher values increase the blur effect.
- This feature is only applied if `album_cover_small = True`.

---

### Example Image

Here’s a visual comparison to show how it looks with and without the blur effect:
| **Without Blur** | **With Blur (`background_blur = 15`)** |
| -------- | ------- |
| ![Without Blur](https://cdn.screenit.app/uploads/lC1T7Y02.jpg) | ![With Blur of Value 15](https://cdn.screenit.app/uploads/YFV0dZBM.jpg) |

---

### Why I Added This
I implemented this feature because I found that the small album cover often lacked contrast against the background, making it hard to see. Applying a slight blur ensures that the album cover remains clearly visible without making the background unrecognizable.