### PR TITLE
Automatic Spotify Token Refresh Service

### DIFF
--- a/python/tokenRefresher.py
+++ b/python/tokenRefresher.py
@@ -1,0 +1,73 @@
+import os
+import time
+import spotipy
+from spotipy.oauth2 import SpotifyOAuth
+import logging
+
+logging.basicConfig(
+    format='%(asctime)s - %(levelname)s - %(message)s',
+    level=logging.INFO
+)
+logger = logging.getLogger("SpotifyTokenRefresher")
+
+ENV_FILE = "/etc/systemd/system/spotipi-eink-display.service.d/spotipi-eink-display_env.conf"
+
+if os.path.exists(ENV_FILE):
+    with open(ENV_FILE, "r") as f:
+        for line in f:
+            if line.startswith("Environment="):
+                try:
+                    env_entry = line.strip().split("=", 1)[1]
+                    key, value = env_entry.split("=", 1)
+                    key = key.strip().strip('"')
+                    value = value.strip().strip('"')
+                    os.environ[key] = value
+                except ValueError as e:
+                    logger.error(f"Error while loading ENV File: {line} - {e}")
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+CACHE_PATH = os.path.join(SCRIPT_DIR, "../config/.cache")
+
+CLIENT_ID = os.environ.get("SPOTIPY_CLIENT_ID")
+CLIENT_SECRET = os.environ.get("SPOTIPY_CLIENT_SECRET")
+REDIRECT_URI = os.environ.get("SPOTIPY_REDIRECT_URI")
+
+if not all([CLIENT_ID, CLIENT_SECRET, REDIRECT_URI]):
+    logger.error("Missing Spotify API envoirenment variables! Check your systemd-env-file.")
+    exit(1)
+
+sp_oauth = SpotifyOAuth(
+    client_id=CLIENT_ID,
+    client_secret=CLIENT_SECRET,
+    redirect_uri=REDIRECT_URI,
+    scope="user-read-currently-playing,user-modify-playback-state",
+    cache_path=CACHE_PATH
+)
+
+
+def refresh_token_if_needed():
+    """chekcs whether the access token is about to expire and renews it if necessary"""
+    token_info = sp_oauth.get_cached_token()
+
+    if not token_info:
+        logger.error("No saved token found! Please authenticate manually once.")
+        return
+
+    expires_at = token_info["expires_at"]
+    current_time = int(time.time())
+
+    if expires_at - current_time < 300:
+        logger.info("Token is about to expire. Refreshing...")
+        new_token_info = sp_oauth.refresh_access_token(token_info["refresh_token"])
+
+        if new_token_info:
+            logger.info("Access token successfully refreshed!")
+        else:
+            logger.error("Error while refreshing access token!")
+
+
+if __name__ == "__main__":
+    logger.info("Spotify Token Refresh Service started...")
+    while True:
+        refresh_token_if_needed()
+        time.sleep(60)

--- a/setup.sh
+++ b/setup.sh
@@ -234,6 +234,28 @@ sudo systemctl start spotipi-eink-display
 sudo systemctl enable spotipi-eink-display
 echo "...done"
 echo
+UID_TO_USE=$(id -u)
+GID_TO_USE=$(id -g)
+echo
+echo "Creating spotipi-eink-token-refresher service:"
+sudo cp "${install_path}/setup/service_template/spotipi-eink-token-refresher.service" /etc/systemd/system/
+sudo sed -i -e "/\[Service\]/a ExecStart=${install_path}/spotipienv/bin/python3 ${install_path}/python/tokenRefresher.py" /etc/systemd/system/spotipi-eink-token-refresher.service
+sudo sed -i -e "/ExecStart/a WorkingDirectory=${install_path}" /etc/systemd/system/spotipi-eink-token-refresher.service
+sudo sed -i -e "/EnvironmentFile/a User=${UID_TO_USE}" /etc/systemd/system/spotipi-eink-token-refresher.service
+sudo sed -i -e "/User/a Group=${GID_TO_USE}" /etc/systemd/system/spotipi-eink-token-refresher.service
+sudo mkdir -p /etc/systemd/system/spotipi-eink-display.service.d
+spotipi_env_path=/etc/systemd/system/spotipi-eink-display.service.d/spotipi-eink-display_env.conf
+if [ ! -f "$spotipi_env_path" ]; then
+    echo "[Service]" | sudo tee -a $spotipi_env_path > /dev/null
+    echo "Environment=\"SPOTIPY_CLIENT_ID=${spotify_client_id}\"" | sudo tee -a $spotipi_env_path > /dev/null
+    echo "Environment=\"SPOTIPY_CLIENT_SECRET=${spotify_client_secret}\"" | sudo tee -a $spotipi_env_path > /dev/null
+    echo "Environment=\"SPOTIPY_REDIRECT_URI=${spotify_redirect_uri}\"" | sudo tee -a $spotipi_env_path > /dev/null
+fi
+sudo systemctl daemon-reload
+sudo systemctl start spotipi-eink-token-refresher
+sudo systemctl enable spotipi-eink-token-refresher
+echo "...done"
+echo
 if [ "$BUTTONS" -eq "1" ]; then
     echo "###### Spotipi-eink button action service installation"
     echo

--- a/setup/service_template/spotipi-eink-token-refresher.service
+++ b/setup/service_template/spotipi-eink-token-refresher.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Spotify E-Ink Display Token Refresher Service
+After=network.target
+StartLimitIntervalSec=300
+StartLimitBurst=5
+
+[Service]
+ExecStart={{ INSTALL_PATH }}/spotipienv/bin/python3 {{ INSTALL_PATH }}/python/spotify_token_refresher.py
+WorkingDirectory={{ INSTALL_PATH }}
+SyslogIdentifier=spotify-token-refresher
+Restart=on-failure
+RestartSec=5s
+KillSignal=SIGINT
+EnvironmentFile=/etc/systemd/system/spotipi-eink-display.service.d/spotipi-eink-display_env.conf
+User={{ USER_ID }}
+Group={{ GROUP_ID }}
+
+[Install]
+WantedBy=multi-user.target

--- a/setup/service_template/spotipi-eink-token-refresher.service
+++ b/setup/service_template/spotipi-eink-token-refresher.service
@@ -5,7 +5,7 @@ StartLimitIntervalSec=300
 StartLimitBurst=5
 
 [Service]
-ExecStart={{ INSTALL_PATH }}/spotipienv/bin/python3 {{ INSTALL_PATH }}/python/spotify_token_refresher.py
+ExecStart={{ INSTALL_PATH }}/spotipienv/bin/python3 {{ INSTALL_PATH }}/python/tokenRefresher.py
 WorkingDirectory={{ INSTALL_PATH }}
 SyslogIdentifier=spotify-token-refresher
 Restart=on-failure


### PR DESCRIPTION
### Description
I noticed that when the Spotify token expires, the service requires a full restart to authenticate again. To fix this, I added a **separate systemd service** that automatically refreshes the Spotify access token before it expires.

This ensures **uninterrupted API access** and prevents authentication failures when no music has been played for a long time. The new service runs independently from the main display service and keeps the token up to date without requiring manual intervention.

---

### Changes I Made
1. **Added `tokenRefresher.py`**
   - A standalone script that monitors the Spotify token and refreshes it before expiration.
   - Uses `SpotifyOAuth.refresh_access_token()` to handle token renewal.
   - Implements dynamic cache path resolution to avoid hardcoded user paths.

2. **Created `spotipi-eink-token-refresher.service` (systemd)**
   - Runs in the background and checks every 60 seconds if the token needs renewal.
   - Ensures a stable connection to the Spotify API **without requiring a service restart**.

3. **Modified the `setup.sh` installation script provided by the project**
   Modified the default `setup.sh` provided by the project itself to install the token refresh service automaticly with the project itself.

---

### How It Works

- The **new token refresher service** runs every 60 seconds.
- If the token expires within the next 5 minutes, it **automatically refreshes it**.
- The **main display service continues running without interruption**.
- The token is **always valid**, even if Spotify hasn’t been played for hours/days.

---

### How to Install
1. Run the Installation Script provided by the project 
The script is automaticly beeing installed with the provided installation method by the Project itself.
2. Check if the service is running
```bash
sudo systemctl status spotipi-eink-token-refresher
```
3. View logs in real-time
```bash
journalctl -u spotipi-eink-token-refresher -f --no-pager
```

---

### Why I Added This

One day, after not playing music on Spotify for a while, I noticed that my eInk display wasn’t updating anymore. At first, I thought it was just a minor glitch, but when I checked the logs, I found something more concerning—the display service was failing to authenticate with the Spotify API.

After manually restarting the service, everything worked fine again. I didn’t think much of it at first, but after this happened **three more times**, it quickly became frustrating. Having to manually restart the service every time just to get the display working again felt unnecessary.

So, I started digging deeper into the issue. That’s when I discovered that the project had **no built-in mechanism to keep the access token up to date**. If no music had been played for a long time, the token would expire, and the service would lose access to the Spotify API. 

After experimenting with different solutions, I realized that the simplest and most effective fix was to create a **separate token refresher service**. This service runs in the background and **ensures that the access token is always up to date**, eliminating the need for manual restarts. Now, the display remains fully functional, even after long periods of inactivity.

---

### Final Toughts
This feature makes the **Spotipi eInk Display more reliable**, ensuring it **always has a valid Spotify token**. With this service, **users never have to worry about authentication errors again**.